### PR TITLE
Fix: resolve issue 26 (`plot_results` fails to save figures when `save_all_h5ad=True`)

### DIFF
--- a/banksy/plot_banksy.py
+++ b/banksy/plot_banksy.py
@@ -89,8 +89,8 @@ def plot_results(
 
         if options['save_all_h5ad']:
             # If we want to save the anndata object as .h5ad format
-            save_path = os.path.join(save_path, f"{dataset_name}_{params_name}.h5ad")
-            adata_temp.write(save_path)
+            h5ad_save_path = os.path.join(save_path, f"{dataset_name}_{params_name}.h5ad")
+            adata_temp.write(h5ad_save_path)
 
         adata_temp.obsm[coord_keys[2]] = np.vstack(
             (adata_temp.obs[coord_keys[0]].values,


### PR DESCRIPTION
**Description:**
This PR fixes an issue in the `plot_results` function where setting `save_all_h5ad=True` unintentionally overrides the `save_path` variable. This caused figure saving (`save_fullfig=True`) to fail.

**Changes:**
Introduced a new local variable for saving `.h5ad` files instead of reusing `save_path`.
Ensured that `save_path` remains unchanged so that figure saving works correctly.

**Related Issue:**
#26.

Thanks for reviewing!