### PR TITLE
`generate_banksy_matrix` bug: pass center and variance_balance as keyword args to `create_nbr_matrix`

### DIFF
--- a/src/banksy/embed_banksy.py
+++ b/src/banksy/embed_banksy.py
@@ -43,7 +43,14 @@ def generate_banksy_matrix(adata: anndata.AnnData,
     for nbr_weight_decay in banksy_dict:
 
         # First create neighbour matrices
-        nbr_matrices = create_nbr_matrix(adata, banksy_dict, nbr_weight_decay, max_m, variance_balance)
+        nbr_matrices = create_nbr_matrix(
+            adata,
+            banksy_dict,
+            nbr_weight_decay,
+            max_m,
+            center=False,
+            variance_balance=variance_balance,
+        )
 
         # Create matrix list
         mat_list, concatenated = create_mat_list(adata, nbr_matrices, max_m)


### PR DESCRIPTION
Previously, variance_balance was being passed positionally wrong into the center parameter, silently coercing a bool into the wrong argument.

This pull request is created only to announce the existence of the bug. I have not modified anything that changes the behaviour of the program.